### PR TITLE
Forward command line parameters to mongod

### DIFF
--- a/entry-point.sh
+++ b/entry-point.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 /bin/bash ./init-replica.sh &
-/bin/bash ./init-mongodbs.sh
+/bin/bash ./init-mongodbs.sh "$@"

--- a/init-mongodbs.sh
+++ b/init-mongodbs.sh
@@ -11,6 +11,6 @@ DB2_LOG_DIR="/var/log/mongodb2"
 DB3_LOG_DIR="/var/log/mongodb3"
 
 
-mongod --dbpath ${DB1_DATA_DIR} --logpath ${DB1_LOG_DIR}/mongod.log --fork --port 27017 --bind_ip_all --replSet rs0 
-mongod --dbpath ${DB2_DATA_DIR} --logpath ${DB2_LOG_DIR}/mongod.log --fork --port 27018 --bind_ip_all --replSet rs0
-mongod --dbpath ${DB3_DATA_DIR} --logpath ${DB3_LOG_DIR}/mongod.log --port 27019 --bind_ip_all --replSet rs0
+mongod --dbpath ${DB1_DATA_DIR} --logpath ${DB1_LOG_DIR}/mongod.log --fork --port 27017 --bind_ip_all --replSet rs0 "$@"
+mongod --dbpath ${DB2_DATA_DIR} --logpath ${DB2_LOG_DIR}/mongod.log --fork --port 27018 --bind_ip_all --replSet rs0 "$@"
+mongod --dbpath ${DB3_DATA_DIR} --logpath ${DB3_LOG_DIR}/mongod.log --port 27019 --bind_ip_all --replSet rs0 "$@"


### PR DESCRIPTION
This allows to set additional startup parameters to the mongod process by overriding the docker COMMAND.

For example from docker-compose

```
  mongo:
    image: davybello/mongo-replica-set:5.0.2
    command: "--setParameter transactionLifetimeLimitSeconds=3600"
```

Or from the command line like

`docker run davybello/mongo-replica-set:5.0.2 --setParameter transactionLifetimeLimitSeconds=3600`
